### PR TITLE
docs: add note regarding 'install' poe task requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,9 @@ If the comment body is `/poe lint`, the action will run `poe lint`.
 
 ## Requirements
 
-- Your repository must use [Poe the Poet](https://github.com/nat-n/poethepoet) and have a valid `pyproject.toml` with Poe tasks defined.
+- Your repository must use [Poe the Poet](https://github.com/nat-n/poethepoet) and have a valid `pyproject.toml`,  `poe_tasks.toml`, or similar config file containing the project's Poe tasks.
 - The action sets up Python 3.11 and installs dependencies using [uv](https://github.com/astral-sh/uv).
+- Your project should have a poe task named `install` which will run before any other requested command.
 - The `github-token` input is required for committing changes and posting comments.
 
 ## Example Usage


### PR DESCRIPTION
<!--- SUMMARY_MARKER --->
## Sweep Summary <sub><a href="https://app.sweep.dev"><img src="https://raw.githubusercontent.com/sweepai/sweep/main/.assets/sweep-square.png" width="25" alt="Sweep"></a></sub>

Updates the README to clarify that an 'install' poe task is required and that Poe tasks can be defined in various config files beyond just pyproject.toml.

- Clarified that Poe tasks can be defined in `pyproject.toml`, `poe_tasks.toml`, or similar config files, not just in pyproject.toml.
- Added documentation that projects should have a poe task named `install` which will run before any other requested command.

---
[Ask Sweep AI questions about this PR](https://app.sweep.dev)
<!--- SUMMARY_MARKER --->