### PR TITLE
feat: add submodules support, add pre-run and post-run markers for better log visibility

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -106,6 +106,7 @@ runs:
       uses: actions/checkout@v4
       with:
         ref: ${{ steps.pr-info.outputs.branch }}
+        submodules: true  # Initialize submodules if needed
         repository: ${{ steps.pr-info.outputs.repo }}
         token: ${{ inputs.github-token }}
 


### PR DESCRIPTION
This PR adds visual markers before and after running poe commands in the CI logs to improve readability and quotes the +1 reaction value for consistency.

Introduce a “Print Pre-Run Marker” step that echoes separators and the poe command being executed.
Introduce a “Print Post-Run Marker” step that echoes separators and the completion message, always running.
Update the reactions field to quote "+1".