### PR TITLE
fix: change major tag workflow trigger from release to tag push events

### DIFF
--- a/.github/workflows/update-major-tags.yml
+++ b/.github/workflows/update-major-tags.yml
@@ -3,7 +3,7 @@ name: Update Major Version Tags
 on:
   push:
     tags:
-      - 'v*.*.*'
+      - 'v[0-9]+.[0-9]+.[0-9]+'
 
 permissions:
   contents: write

--- a/.github/workflows/update-major-tags.yml
+++ b/.github/workflows/update-major-tags.yml
@@ -1,8 +1,9 @@
 name: Update Major Version Tags
 
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - 'v*.*.*'
 
 permissions:
   contents: write


### PR DESCRIPTION
# Fix GitHub Actions workflow failure in major version tag management

## Summary

This PR fixes the GitHub Actions workflow failure that occurred when the major version tag management workflow was triggered by `release.published` events. The root cause was that the `nowactions/update-majorver@v1` action expects the GitHub context from tag push events, not release publication events.

**Key Changes:**
- Changed trigger from `on.release.types: [published]` to `on.push.tags: ['v*.*.*']`
- Reverted back to using the original `nowactions/update-majorver@v1` action
- Simplified approach: trigger on semantic version tag pushes instead of release events

**Workflow Behavior Change:**
- **Before**: Major tags updated when releases are published
- **After**: Major tags updated when semantic version tags (v*.*.*) are pushed

This maintains the two-workflow approach but changes the timing of major tag updates.

## Review & Testing Checklist for Human

- [ ] **Verify workflow timing aligns with release strategy** - Major tags now update on tag push rather than release publication. Confirm this matches your intended release workflow.
- [ ] **Test end-to-end workflow** - Create a test semantic version tag (e.g., `v1.4.0`) and verify that the major tag (e.g., `v1`) is automatically updated to point to the new tag.
- [ ] **Validate tag pattern** - Confirm the pattern `v*.*.*` matches your repository's existing tag format (currently using tags like `v1.3.1`).

**Recommended Test Plan:**
1. Merge this PR
2. Create and push a new semantic version tag: `git tag v1.4.0 && git push origin v1.4.0`
3. Verify the workflow runs successfully and updates the `v1` tag to point to `v1.4.0`
4. Test that the release-drafter workflow still works by merging a PR to main

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TB
    subgraph "Release Management Workflows"
        A["main branch<br/>merges"]
        B["tag pushes<br/>(v*.*.*)"]
        C[".github/workflows/<br/>release-drafter.yml"]:::context
        D[".github/workflows/<br/>update-major-tags.yml"]:::major-edit
        E["nowactions/<br/>update-majorver@v1"]:::context
        F["Draft releases<br/>created/updated"]
        G["Major tags<br/>(v1, v2) updated"]
    end
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit
        L3[Context/No Edit]:::context
    end
    
    A --> C
    B --> D
    C --> F
    D --> E
    E --> G

classDef major-edit fill:#90EE90
classDef minor-edit fill:#87CEEB
classDef context fill:#FFFFFF
```

### Notes

- **Root Cause**: The `nowactions/update-majorver@v1` action was designed to work with tag push events (`github.ref` context) but was being triggered by release publication events (`github.event.release` context), causing undefined property access errors.
- **Alternative Considered**: I initially implemented a custom bash script solution to work with release events, but @aaronsteers correctly suggested the simpler approach of using tag push triggers.
- **Session Details**: Requested by @aaronsteers - [Devin session](https://app.devin.ai/sessions/e708ac162b084dc3935cd7c3aa7d5d80)

**Risk Assessment**: 🟡 Medium - The workflow behavior change (tag push vs release publication timing) needs verification to ensure it aligns with the intended release management strategy.